### PR TITLE
Version 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sort ES6 imports for JavaScript and TypeScript automatically.
 Ported from the [atom-import-sort](https://atom.io/packages/atom-import-sort) package by [Renke Grunwald](https://github.com/renke).
 
-![Sort Example](http://i.imgur.com/XEzc7EU.gif)
+![Sort Example](https://i.imgur.com/XEzc7EU.gif)
 
 ## Features
 
@@ -21,9 +21,11 @@ You can also save the document without saving imports. This could become handy w
 
 This extension has the following settings:
 
-* `sort-imports.on-save`: enable/disable auto sorting on save (default: true).
-* `sort-imports.suppress-warnings`: suppress warnings if sorting imports fails (default: false).
-* `sort-imports.languages`: selectively choose the languages which should be sported (default: ['javascript', 'typescript']).
+* `sort-imports.default-sort-style`: sorting style if `package.json` doesn't have `import-sort` key (default: `eslint`).
+* `sort-imports.on-save`: enable/disable auto sorting on save (default: `true`).
+* `sort-imports.suppress-warnings`: suppress warnings if sorting imports fails (default: `false`).
+* `sort-imports.languages`: selectively choose the languages which should be sported (default: `['javascript', 'typescript']`).
+* `sort-imports.cache-package-json-config-checks`: performance optimization, disable if necessary (default: `true`).
 
 ### Obsolete settings
 
@@ -52,7 +54,7 @@ The keys are a list of file extensions that map to the parser and style that sho
 
 By default, `sort-import` comes with these styles:
 
-* [`import-sort-style-eslint` (default)](https://github.com/renke/import-sort/tree/master/packages/import-sort-style-eslint): A style that that is compatible with [ESLint's](http://eslint.org/) [sort-imports](http://eslint.org/docs/rules/sort-imports) rule.
+* [`import-sort-style-eslint` (default)](https://github.com/renke/import-sort/tree/master/packages/import-sort-style-eslint): A style that that is compatible with [ESLint's](http://eslint.org/) [sort-imports](https://eslint.org/docs/rules/sort-imports) rule.
 
 * [`import-sort-style-module`](https://github.com/renke/import-sort/tree/master/packages/import-sort-style-module): A style that groups and sorts by module.
 
@@ -64,8 +66,8 @@ PRs with more styles are welcome.
 
 ### 4.1.0
 * Implemented by [@cliffkoh](https://github.com/cliffkoh)
-  * Introduced `sort-imports.default-sort-style`, which defaults to `module-compact`. Other possible values are `module` and `eslint`.
-  * Introduced `sort-imports.cache-package-json-config-checks` which defaults to `true`. When true, will cache calls to `import-sort-config` thereby improving performance 
+  * Introduced `sort-imports.default-sort-style`, which defaults to `eslint`. Other possible values are `module`, `module-compact` and `module-scoped`.
+  * Introduced `sort-imports.cache-package-json-config-checks` which defaults to `true`. When true, will cache calls to `import-sort-config` thereby improving performance
   (avoids repeated non-trival disk lookups and parsing).
   * Fixed bug in `Save file without sorting import` which caused it to not work.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sort-imports",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -51,6 +51,15 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -60,6 +69,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.9",
@@ -855,12 +870,12 @@
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.1.tgz",
+      "integrity": "sha1-xKNGK6FK3137q3lzH9OESiBpy7s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
         "time-stamp": "1.1.0"
       }
     },
@@ -1421,7 +1436,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "2.2.0",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.1",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -1676,9 +1691,9 @@
       "integrity": "sha1-P/qSPGY6GcL3jiIvEtLejacUbS8="
     },
     "import-sort-style-module-scoped": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/import-sort-style-module-scoped/-/import-sort-style-module-scoped-1.0.1.tgz",
-      "integrity": "sha512-Xn3PcjyXOjkY5rfDI/sc4IIfsgx9WizBjG/ScgvqM2meYbptXWRtRZJHW6on2RsagggpST7PkRiXb+WoB80QJQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/import-sort-style-module-scoped/-/import-sort-style-module-scoped-1.0.2.tgz",
+      "integrity": "sha512-ymfQk36YrvUEfi0djdbO9n0IGVzmggH0uVTLCfO0qwZ4Egmb5SSuMXxdRcj5rDWbdgre0P7zsggXmRdLzf8njA=="
     },
     "imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sort-imports",
   "displayName": "sort-imports",
   "description": "Sort ES6 imports automatically.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "galleryBanner": {
     "color": "#2980b9",
     "theme": "dark"
@@ -93,7 +93,7 @@
   "devDependencies": {
     "@types/node": "^6.0.46",
     "typescript": "^2.0.6",
-    "vscode": "^1.0.3"
+    "vscode": "^1.1.10"
   },
   "dependencies": {
     "import-sort": "4.2.0",
@@ -103,6 +103,6 @@
     "import-sort-style-eslint": "^4.0.0",
     "import-sort-style-module": "^4.0.0",
     "import-sort-style-module-compact": "^1.0.0",
-    "import-sort-style-module-scoped": "^1.0.1"
+    "import-sort-style-module-scoped": "^1.0.2"
   }
 }


### PR DESCRIPTION
- Bump version
- Add documentation for new options
- Updated dependencies
- Fix default value for `default-sort-style` on changelog.