### PR TITLE
Add extra module

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "import-sort-style-eslint": "^4.0.0",
     "import-sort-style-module": "^4.0.0",
     "import-sort-style-module-compact": "^1.0.0",
-    "import-sort-style-module-scoped": "^1.0.3"
+    "import-sort-style-module-scoped": "^1.0.3",
+    "import-sort-style-module-scoped-ordered": "^1.0.3"
   }
 }


### PR DESCRIPTION
module-scoped is great but the separator between scoped imports is annoying. This fork of mine just orders scoped imports last in the external module section.
```
import test from 'test';
import test1 from '@test/test1';
```