### PR TITLE
Make cursor not to jump to the end of file when sorting is done

### DIFF
--- a/src/on-save.ts
+++ b/src/on-save.ts
@@ -1,8 +1,9 @@
 import {
     Disposable,
     TextDocumentWillSaveEvent,
-    TextEdit,
     workspace,
+    window,
+    TextEditorEdit,
 } from 'vscode';
 import { sort } from './sort';
 import { getConfiguration, getMaxRange } from './utils';
@@ -58,6 +59,11 @@ function listener({ document, waitUntil }: TextDocumentWillSaveEvent) {
         return;
     }
 
-    const edits = Promise.resolve([new TextEdit(getMaxRange(), sortedText)]);
-    waitUntil(edits);
+    const editor = window.activeTextEditor;
+
+    const editPromise = editor.edit((edit: TextEditorEdit) => {
+        edit.replace(getMaxRange(), sortedText);
+    });
+
+    waitUntil(editPromise);
 }

--- a/src/on-save.ts
+++ b/src/on-save.ts
@@ -58,7 +58,7 @@ export default {
 function listener({ document, waitUntil }: TextDocumentWillSaveEvent) {
     const sortedText = sort(document);
     if (!sortedText) {
-      return;
+        return;
     }
 
     waitUntil(changeContentOfDocument(document, sortedText));


### PR DESCRIPTION
Hi

This fixes #7.

I don't know this extension enough so that I could tell that it doesn't break anything else.
