### PR TITLE
docs: add a note on how to ignore files inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ By default, `sort-imports` comes with these styles:
 
 PRs with more styles are welcome.
 
+## Ignoring files
+Sometimes the imports in a certain file should not be sorted. To prevent import-sort from sorting a particular file, just add `// import-sort-ignore` or `/* import-sort-ignore */` to your file. Anwhere in the file is fine.
+
 ## Troubleshooting
 
 ### `parser.parseImports is not a function`


### PR DESCRIPTION
I needed to disable `sort-imports` for some files, and had go to the upstream repo to search for this option. I thought we could improve the documentation here a little, hence this PR 🙂 

I copied the "Ignore files" section over from https://github.com/renke/import-sort#ignoring-files.

